### PR TITLE
Add calculator and Latin buttons with Applus orange navbar

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,3 +80,47 @@ themeToggle.addEventListener('click', () => {
   const newTheme = body.classList.contains('dark') ? 'light' : 'dark';
   setTheme(newTheme);
 });
+
+// Calculator functionality
+const openCalcBtn = document.getElementById('open-calculator');
+const calculatorSection = document.getElementById('calculator');
+const calcInput = document.getElementById('calc-expression');
+const calcEvaluate = document.getElementById('calc-evaluate');
+const calcClose = document.getElementById('calc-close');
+const calcResult = document.getElementById('calc-result');
+
+openCalcBtn.addEventListener('click', () => {
+  calculatorSection.classList.remove('hidden');
+});
+
+calcClose.addEventListener('click', () => {
+  calculatorSection.classList.add('hidden');
+  calcInput.value = '';
+  calcResult.textContent = '';
+});
+
+calcEvaluate.addEventListener('click', () => {
+  try {
+    const result = Function(`"use strict";return(${calcInput.value})`)();
+    calcResult.textContent = result;
+  } catch (err) {
+    calcResult.textContent = 'Error';
+  }
+});
+
+// Latin phrases
+const latinBtn = document.getElementById('latin-button');
+const latinSection = document.getElementById('latin-section');
+const latinOutput = document.getElementById('latin-output');
+const latinPhrases = [
+  'Lorem ipsum dolor sit amet',
+  'Carpe diem',
+  'Veni, vidi, vici',
+  'Alea iacta est'
+];
+
+latinBtn.addEventListener('click', () => {
+  const phrase = latinPhrases[Math.floor(Math.random() * latinPhrases.length)];
+  latinSection.classList.remove('hidden');
+  latinOutput.textContent = phrase;
+});

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <nav class="navbar glass">
+  <nav class="navbar">
     <div class="nav-left">Pretty GUI</div>
     <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
   </nav>
@@ -16,6 +16,8 @@
       <ul>
         <li><a href="#tasks">Tasks</a></li>
         <li><a href="#notes">Notes</a></li>
+        <li><button id="open-calculator">Calculadora</button></li>
+        <li><button id="latin-button">Latín</button></li>
       </ul>
     </aside>
     <main class="content">
@@ -30,6 +32,19 @@
       <section id="notes" class="widget glass">
         <h2>Notes</h2>
         <textarea id="notes-area" placeholder="Write your notes here..."></textarea>
+      </section>
+      <section id="calculator" class="widget glass hidden">
+        <h2>Calculadora</h2>
+        <input type="text" id="calc-expression" placeholder="e.g., 2+2 or Math.sin(Math.PI/2)">
+        <div class="calc-controls">
+          <button id="calc-evaluate">Calcular</button>
+          <button id="calc-close">Cerrar</button>
+        </div>
+        <div id="calc-result"></div>
+      </section>
+      <section id="latin-section" class="widget glass hidden">
+        <h2>Latín</h2>
+        <p id="latin-output"></p>
       </section>
     </main>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,8 @@ body {
   justify-content: space-between;
   padding: 0 1rem;
   z-index: 1000;
+  background: #FF5F00;
+  color: #fff;
 }
 
 .navbar button {
@@ -46,7 +48,7 @@ body {
   border: none;
   font-size: 1.2rem;
   cursor: pointer;
-  color: var(--text);
+  color: #fff;
 }
 
 .container {
@@ -71,6 +73,18 @@ body {
   padding: 0.5rem 0;
   color: var(--text);
   text-decoration: none;
+}
+
+.sidebar button {
+  display: block;
+  padding: 0.5rem 0;
+  background: none;
+  border: none;
+  color: var(--text);
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  font: inherit;
 }
 
 .content {
@@ -138,6 +152,39 @@ body {
   cursor: pointer;
   color: var(--text);
   font-size: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+#calculator input {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text);
+}
+
+#calculator .calc-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+#calculator .calc-controls button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  background: var(--glass-bg);
+  color: var(--text);
+}
+
+#calc-result {
+  margin-top: 0.5rem;
+  min-height: 1.5rem;
 }
 
 #notes-area {


### PR DESCRIPTION
## Summary
- Make navbar Applus orange and ensure white text
- Add sidebar buttons to launch calculator and display Latin text
- Implement scientific calculator widget and random Latin phrase output

## Testing
- `node --check app.js`
- `npx --yes serve` *(fails: 403 Forbidden - GET https://registry.npmjs.org/serve)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b3c41948324aefae00ad61fec11